### PR TITLE
Add NetBeans project files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,10 @@ buildSystem/__pycache__
 *.pyc
 testBuilds
 
+# NetBeans original backup files
+*.orig
+
+# NetBeans project files
+/nbproject/
+
+


### PR DESCRIPTION
Added /nbproject/ and NetBeans `.orig` to the list of extensions and directories that should be ignored by git.